### PR TITLE
fix: 修复友链头像中文URL双重编码问题

### DIFF
--- a/templates/links.html
+++ b/templates/links.html
@@ -6,9 +6,17 @@
               th:with="defaultAvatar = ${#strings.defaultString(theme.config.page_config.links_default_avatar, #theme.assets('/img/avatar.svg'))}">
         <script>
           function setSafeSrc(element, url) {
-            // 允许：http/https/data:image 协议 或 相对路径（以/开头）
-            var isSafe = /^(https?|data:image\/[a-z]+;base64|\/)/i.test(url)
-            element.src = isSafe ? encodeURI(url) : '' // 不安全则清空
+            // 空值检查：防止 url 为空或 undefined 时报错
+            if (!url) { element.src = ''; return; }
+            
+            // 安全协议检查：只允许 http/https/data:image/相对路径
+            var isSafe = /^(https?|data:image\/[a-z]+;base64|\/)/i.test(url);
+            if (!isSafe) { element.src = ''; return; }
+            
+            // 编码检测：检查URL是否已包含 %XX 格式的编码字符
+            // 如果已编码则直接使用，避免双重编码导致 400 Bad Request
+            // 如果未编码则使用 encodeURI() 处理中文等特殊字符
+            element.src = /%[0-9A-Fa-f]{2}/.test(url) ? url : encodeURI(url);
           }
         </script>
         <div class="card">

--- a/templates/links.html
+++ b/templates/links.html
@@ -14,8 +14,7 @@
             if (!isSafe) { element.src = ''; return; }
             
             // 检查URL是否已编码（包含百分号编码字符）
-            var encodedPattern = /%[0-9A-Fa-f]{2}/;
-            element.src = encodedPattern.test(url) ? url : encodeURI(url);
+            element.src = encodeURI(decodeURI(url));;
           }
         </script>
         <div class="card">

--- a/templates/links.html
+++ b/templates/links.html
@@ -13,7 +13,7 @@
             var isSafe = /^(https?|data:image\/[a-z]+;base64|\/)/i.test(url);
             if (!isSafe) { element.src = ''; return; }
             
-            // 编码检测：检查URL是否已包含 %XX 格式的编码字符
+            // 编码检测：检查URL是否已包含百分号编码格式的字符
             // 如果已编码则直接使用，避免双重编码导致 400 Bad Request
             // 如果未编码则使用 encodeURI() 处理中文等特殊字符
             element.src = /%[0-9A-Fa-f]{2}/.test(url) ? url : encodeURI(url);

--- a/templates/links.html
+++ b/templates/links.html
@@ -13,10 +13,9 @@
             var isSafe = /^(https?|data:image\/[a-z]+;base64|\/)/i.test(url);
             if (!isSafe) { element.src = ''; return; }
             
-            // 编码检测：检查URL是否已包含百分号编码格式的字符
-            // 如果已编码则直接使用，避免双重编码导致 400 Bad Request
-            // 如果未编码则使用 encodeURI() 处理中文等特殊字符
-            element.src = /%[0-9A-Fa-f]{2}/.test(url) ? url : encodeURI(url);
+            // 检查URL是否已编码（包含百分号编码字符）
+            var encodedPattern = /%[0-9A-Fa-f]{2}/;
+            element.src = encodedPattern.test(url) ? url : encodeURI(url);
           }
         </script>
         <div class="card">


### PR DESCRIPTION
## 问题描述

友链页面中，当头像URL包含中文或已编码字符时，会出现 400 Bad Request 错误。

**错误示例**：

`GET https://www.example.com/upload/%25E5%25A4%25B4%25E5%2583%258F.png 400 (Bad Request)`


## 根本原因

`setSafeSrc` 函数对所有URL都执行 `encodeURI()`，导致已编码的URL被双重编码：
- 原始URL：`%E5%A4%B4%E5%83%8F.png`（已编码的"头像.png"）
- 双重编码后：`%25E5%25A4%25B4%25E5%2583%258F.png`

## 修复方案

在 `templates/links.html` 中修改 `setSafeSrc` 函数：

1. 增加空值检查，防止报错
2. 使用正则 `/%[0-9A-Fa-f]{2}/` 检测URL是否已编码
3. 已编码的URL直接使用，未编码的URL才执行 `encodeURI()`

## 修改文件

- `templates/links.html` - 修改 `setSafeSrc` 函数（第8-12行）

## 兼容性

- ✅ 向后兼容，不影响现有功能
- ✅ 无新增依赖